### PR TITLE
Set lower boundaries on direct dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,15 @@ from setuptools import setup, find_packages
 with open("./README.md", "r") as f:
     long_description = f.read()
 
-requires = ["regex", "pyroaring", "starlette", "jinja2", "click"]
+requires = [
+    "click>=8.1.0",
+    "jinja2>=3.1.0",
+    "pyroaring>=0.3.3",
+    "regex>=2022.4.24",
+    "starlette>=0.20.0",
+    "uvicorn>=0.17.0",
+]
+
 
 setup(
     name="hyperreal",


### PR DESCRIPTION
Also include uvicorn as a dependency (it turns out it isn't a specified dependency of starlette...).

This does something similar to #2, but puts the missing uvicorn dependency into setup.py. The main difference between the two is that setup.py is read when creating and uploading the package to PyPI, so will also work in  the future when this is published and people start running `pip install hyperreal`. We also want to be careful not to pin things to specific versions, as that will limit how other people can use this with other software (see https://caremad.io/posts/2013/07/setup-vs-requirement/ ).