### PR TITLE
Starting point for splitting or further subdividing clusters

### DIFF
--- a/hyperreal/cli.py
+++ b/hyperreal/cli.py
@@ -56,7 +56,8 @@ def plaintext_corpus_create(text_file, corpus_db):
 @plaintext_corpus.command(name="index")
 @click.argument("corpus_db", type=click.Path(exists=True, dir_okay=False))
 @click.argument("index_db", type=click.Path(dir_okay=False))
-def plaintext_corpus_index(corpus_db, index_db):
+@click.option("--processes", type=int, default=None)
+def plaintext_corpus_index(corpus_db, index_db, processes):
     """
     Creates the index database representing the given plaintext corpus.
 
@@ -68,7 +69,7 @@ def plaintext_corpus_index(corpus_db, index_db):
     doc_corpus = hyperreal.corpus.PlainTextSqliteCorpus(corpus_db)
     doc_index = hyperreal.index.Index(index_db, corpus=doc_corpus)
 
-    doc_index.index()
+    doc_index.index(n_cpus=processes)
 
 
 @plaintext_corpus.command(name="serve")
@@ -128,7 +129,8 @@ def stackexchange_corpus_create(posts_file, comments_file, users_file, corpus_db
 @stackexchange_corpus.command(name="index")
 @click.argument("corpus_db", type=click.Path(exists=True, dir_okay=False))
 @click.argument("index_db", type=click.Path(dir_okay=False))
-def stackexchange_corpus_index(corpus_db, index_db):
+@click.option("--processes", type=int, default=None)
+def stackexchange_corpus_index(corpus_db, index_db, processes):
     """
     Creates the index database representing the given Stack Exchange corpus.
 
@@ -140,7 +142,7 @@ def stackexchange_corpus_index(corpus_db, index_db):
     doc_corpus = hyperreal.corpus.StackExchangeCorpus(corpus_db)
     doc_index = hyperreal.index.Index(index_db, corpus=doc_corpus)
 
-    doc_index.index()
+    doc_index.index(n_cpus=processes)
 
 
 @stackexchange_corpus.command(name="serve")

--- a/hyperreal/corpus.py
+++ b/hyperreal/corpus.py
@@ -491,8 +491,11 @@ class StackExchangeCorpus(SqliteBackedCorpus):
     def index(self, doc):
         return {
             "Post": hyperreal.utilities.tokens(
-                hyperreal.utilities.strip_tags(
-                    (doc["Title"] or "") + " " + (doc["Body"] or "")
+                (doc["Title"] or "")
+                + " "
+                + " ".join(
+                    l.strip()
+                    for l in hyperreal.utilities.text_from_html(doc["Body"] or "")
                 )
             ),
             "Tag": doc["Tags"],

--- a/hyperreal/templates/base.html
+++ b/hyperreal/templates/base.html
@@ -21,10 +21,10 @@
 
 .cluster-list li {
     padding-left: 0;
-    max-width: 40em;
 }
 
 .compact-cluster {
+    max-width: 40em;
     margin: 1em;
     padding: 0.5em;
     padding-left: 0;
@@ -33,7 +33,7 @@
 .compact-cluster li {
     display: inline-block;
     list-style-type: none;
-    margin: 0.25em 0.5em;
+    margin: 0.25em;
     padding-left: 0;
 }
 
@@ -53,6 +53,24 @@
 
 img {
     max-width: 100%;
+}
+
+.feature {
+  border: 0.1em solid black;
+  border-radius: 0.2em;
+  display: inline-block;
+  margin: 0 0.5em;
+}
+
+.field {
+  background: black;
+  color: white;
+  height:  100%;
+  padding: 0 0.5em;
+}
+
+.value {
+    padding: 0 0.5em;
 }
 
     </style>

--- a/hyperreal/templates/cluster.html
+++ b/hyperreal/templates/cluster.html
@@ -20,10 +20,19 @@
         <button type="submit" formaction="/index/{{ index_id }}/cluster/create" method="post">Create New Cluster</button>
     </form>
 </details>
+
 <ul class="compact-cluster">
-    {% for feature_id, field, value, count in features %}
-    <li><a class="feature-link" href="/index/{{ index_id }}/cluster/{{cluster_id}}?feature_id={{ feature_id }}">{{ field }}: {{ value }}</a> ({{ count }})</li>
+
+    {% for feature_id, field, value, score in features %}
+    <li>
+        <a class="feature-link" href="/index/{{ index_id }}/cluster/{{ cluster_id }}?feature_id={{ feature_id }}">
+            <div class="feature">
+                <span class="field">{{ field }}</span>
+                <span class="value">{{ value }}</span></div>
+        </a>
+    </li>
     {% endfor %}
+
 </ul>
 
 {% endblock %}

--- a/hyperreal/templates/index.html
+++ b/hyperreal/templates/index.html
@@ -29,7 +29,13 @@
     <li>
         <ul class="compact-cluster">
             {% for feature_id, field, value, score in features %}
-            <li><a class="feature-link" href=/index/{{ index_id }}/?feature_id={{ feature_id }}>{{ field }}: {{ value }}</a><!-- ({{ score }}) --></li>
+            <li>
+                <a class="feature-link" href="/index/{{ index_id }}/?feature_id={{ feature_id }}">
+                    <div class="feature">
+                        <span class="field">{{ field }}</span>
+                        <span class="value">{{ value }}</span></div>
+                </a>
+            </li>
             {% endfor %}
             <a href="/index/{{ index_id }}/cluster/{{ cluster_id }}">...</a>
         </ul>
@@ -57,7 +63,13 @@
     <li>
         <ul class="compact-cluster">
             {% for feature_id, field, value, score in features %}
-            <li><a class="feature-link" href=/index/{{ index_id }}/?feature_id={{ feature_id }}>{{ field }}: {{ value }}</a><!-- ({{ score }}) --></li>
+            <li>
+                <a class="feature-link" href="/index/{{ index_id }}/?feature_id={{ feature_id }}">
+                    <div class="feature">
+                        <span class="field">{{ field }}</span>
+                        <span class="value">{{ value }}</span></div>
+                </a>
+            </li>
             {% endfor %}
             <a href="/index/{{ index_id }}/cluster/{{ cluster_id }}">...</a>
         </ul>

--- a/hyperreal/utilities.py
+++ b/hyperreal/utilities.py
@@ -35,19 +35,17 @@ plain_text_tokenizer = regex.compile(
 
 def social_media_tokens(entry):
     cleaned = social_media_cleaner.sub("", entry.lower())
-    return [token for token in word_tokenizer.split(cleaned) if token]
+    return [token for token in word_tokenizer.split(cleaned) if token.strip()]
 
 
 def tokens(entry):
     cleaned = entry.lower()
-    return [token for token in word_tokenizer.split(cleaned) if token]
+    return [token for token in word_tokenizer.split(cleaned) if token.strip()]
 
 
-class MLStripper(HTMLParser):
+class HTMLTextLines(HTMLParser):
     """
-    Strips tags from the provided HTML, retaining only the base text.
-
-    Via https://stackoverflow.com/questions/753052/strip-html-from-strings-in-python
+    Parser for extracting the text from the data elements of given HTML.
 
     """
 
@@ -56,16 +54,22 @@ class MLStripper(HTMLParser):
         self.reset()
         self.strict = False
         self.convert_charrefs = True
-        self.text = StringIO()
+        self.lines = []
 
     def handle_data(self, d):
-        self.text.write(d)
+        self.lines.append(d)
 
-    def get_data(self):
-        return self.text.getvalue()
+    def get_lines(self):
+        return self.lines
 
 
-def strip_tags(html):
-    s = MLStripper()
+def text_from_html(html):
+    """
+    Returns a list of the text contained in the data elements of the given HTML string.
+
+    """
+    s = HTMLTextLines()
     s.feed(html)
-    return s.get_data()
+    lines = s.get_lines()
+    s.close()
+    return lines


### PR DESCRIPTION
- Refactors the clustering algorithm to make it more flexible, with a low level primitive that can be used in different contexts
- Adds a method to propose a split for a given cluster
- Also some miscellaneous styling and other fixes that I should have put on a separate branch
- Fixes for stackexchange corpuses, making sure to only treat the body of a post as html