### PR TITLE
Add structure to handle index migrations

### DIFF
--- a/hyperreal/_index_schema.py
+++ b/hyperreal/_index_schema.py
@@ -1,0 +1,211 @@
+"""
+_schema.py: used for managing the schema of the index database.
+
+Migrations are handled as follows:
+
+1. The CURRENT_SCHEMA script always represents the current schema of the
+database, associated with CURRENT_SCHEMA_VERSION.
+2. The migrations dict maps earlier application versions to:
+    - a sequence of statements to be run before applying CURRENT_SCHEMA
+    - a sequence of statements to be run after applying CURRENT_SCHEMA
+
+"""
+
+# The application ID uses SQLite's pragma application_id to quickly identify index
+# databases from everything else.
+MAGIC_APPLICATION_ID = 715973853
+CURRENT_SCHEMA_VERSION = 5
+
+CURRENT_SCHEMA = f"""
+    create table if not exists doc_key (
+        doc_id integer primary key,
+        doc_key unique
+    );
+
+    --------
+    create table if not exists inverted_index (
+        feature_id integer primary key,
+        field text not null,
+        value not null,
+        docs_count integer not null,
+        doc_ids roaring_bitmap not null,
+        unique (field, value)
+    );
+
+    --------
+    create table if not exists field_summary (
+        field text primary key,
+        distinct_values integer,
+        min_value,
+        max_value
+    );
+
+    --------
+    create index if not exists docs_counts on inverted_index(docs_count);
+    --------
+    create index if not exists field_docs_counts on inverted_index(field, docs_count);
+
+    --------
+    -- The summary table for clusters, including the loose hierarchy
+    -- and the materialised results of the query and document counts.
+    create table if not exists cluster (
+        cluster_id integer primary key,
+        feature_count integer default 0,
+        docs_count integer default 0,
+        doc_ids roaring_bitmap
+    );
+
+    --------
+    create table if not exists feature_cluster (
+        feature_id integer primary key references inverted_index(feature_id) on delete cascade,
+        cluster_id integer references cluster(cluster_id) on delete cascade,
+        docs_count integer
+    );
+
+    --------
+    create index if not exists cluster_features on feature_cluster(
+        cluster_id,
+        docs_count
+    );
+
+    --------
+    -- Used to track when clusters have changed, to mark that housekeeping
+    -- functions need to run.
+    create table if not exists cluster_changed (
+        cluster_id integer primary key references cluster on delete cascade
+    );
+
+    --------
+    create trigger if not exists mark_cluster_changed after update of feature_count on cluster
+        begin
+            insert or ignore into cluster_changed values(new.cluster_id);
+        end;
+
+    --------
+    -- These triggers make sure that the cluster table always demonstrates
+    -- which clusters are currently active, and allows the creation of tracking
+    -- metadata for new clusters on insert of the features.
+    create trigger if not exists ensure_cluster before insert on feature_cluster
+        begin
+            insert or ignore into cluster(cluster_id) values (new.cluster_id);
+            update cluster set
+                feature_count = feature_count + 1
+            where cluster_id = new.cluster_id;
+        end;
+
+    --------
+    create trigger if not exists delete_feature_cluster after delete on feature_cluster
+        begin
+            update cluster set
+                feature_count = feature_count - 1
+            where cluster_id = old.cluster_id;
+            delete from cluster
+            where cluster_id = old.cluster_id
+                and feature_count = 0;
+        end;
+
+    --------
+    create trigger if not exists ensure_cluster_update before update on feature_cluster
+        when old.cluster_id != new.cluster_id
+        begin
+            insert or ignore into cluster(cluster_id) values (new.cluster_id);
+        end;
+
+    --------
+    create trigger if not exists update_cluster_feature_counts after update on feature_cluster
+        when old.cluster_id != new.cluster_id
+        begin
+            update cluster set
+                feature_count = feature_count + 1
+            where cluster_id = new.cluster_id;
+            update cluster set
+                feature_count = feature_count - 1
+            where cluster_id = old.cluster_id;
+            delete from cluster
+            where cluster_id = old.cluster_id
+                and feature_count = 0;
+        end;
+
+    --------
+    pragma user_version = { CURRENT_SCHEMA_VERSION };
+    --------
+    pragma application_id = { MAGIC_APPLICATION_ID };
+"""
+
+migrations = {
+    4: (
+        [
+            "alter table cluster add column docs_count integer default 0",
+            "alter table cluster add column doc_ids roaring_bitmap",
+        ],
+        [
+            "insert into cluster_changed select cluster_id from cluster",
+        ],
+    )
+}
+
+
+class MigrationError(ValueError):
+    pass
+
+
+class IndexVersionMismatch(ValueError):
+    pass
+
+
+def migrate(db):
+    """
+    Migrate the database to the current version of the index schema.
+
+    Returns True if a migration operation ran, False otherwise.
+
+    """
+
+    db_version = list(db.execute("pragma user_version"))[0][0]
+
+    if db_version == 0:
+        # Check that this is a database with no tables, and error if not - don't
+        # want to create these tables on top of an unrelated database.
+        table_count = list(db.execute("select count(*) from sqlite_master"))[0][0]
+
+        if table_count > 0:
+            raise MigrationError(
+                f"Database at '{db_path}' is not empty, and cannot be used as an index."
+            )
+        else:
+            db.execute("begin")
+
+            for statement in CURRENT_SCHEMA.split("--------"):
+                db.execute(statement)
+
+            db.execute("commit")
+
+        # Note that an initialisation is treated as if the index already existed
+        # as in this case there won't be any further action to take.
+        return False
+
+    elif db_version == CURRENT_SCHEMA_VERSION:
+        return False
+
+    elif db_version in migrations:
+
+        db.execute("begin")
+
+        # Run premigration steps
+        for statement in migrations[db_version][0]:
+            db.execute(statement)
+
+        # Run the schema script
+        for statement in CURRENT_SCHEMA.split("--------"):
+            db.execute(statement)
+
+        # Run postmigration steps
+        for statement in migrations[db_version][1]:
+            db.execute(statement)
+
+        db.execute("commit")
+
+        return True
+
+    else:
+        raise MigrationError(f"Unknown database schema version '{db_version}'")

--- a/hyperreal/cli.py
+++ b/hyperreal/cli.py
@@ -100,7 +100,6 @@ def plaintext_corpus_serve(corpus_db, index_db):
             corpus_class=hyperreal.corpus.PlainTextSqliteCorpus,
             corpus_args=[corpus_db],
             pool=pool,
-            mp_context=mp_context,
         )
         hyperreal.server.launch_web_server(index_server)
 
@@ -180,7 +179,6 @@ def stackexchange_corpus_serve(corpus_db, index_db):
             corpus_class=hyperreal.corpus.StackExchangeCorpus,
             corpus_args=[corpus_db],
             pool=pool,
-            mp_context=mp_context,
         )
         hyperreal.server.launch_web_server(index_server)
 
@@ -236,7 +234,5 @@ def serve(index_db):
 
     mp_context = mp.get_context("spawn")
     with cf.ProcessPoolExecutor(mp_context=mp_context) as pool:
-        index_server = hyperreal.server.SingleIndexServer(
-            index_db, pool=pool, mp_context=mp_context
-        )
+        index_server = hyperreal.server.SingleIndexServer(index_db, pool=pool)
         hyperreal.server.launch_web_server(index_server)

--- a/hyperreal/server.py
+++ b/hyperreal/server.py
@@ -217,7 +217,6 @@ class SingleIndexServer:
         corpus_args=None,
         corpus_kwargs=None,
         pool=None,
-        mp_context=None,
     ):
         """
         Helper class for serving a single index via the webserver.
@@ -233,7 +232,6 @@ class SingleIndexServer:
         self.corpus_kwargs = corpus_kwargs
         self.index_path = index_path
 
-        self.mp_context = mp_context
         self.pool = pool
 
     def index(self, index_id):
@@ -247,9 +245,7 @@ class SingleIndexServer:
         else:
             corpus = None
 
-        return hyperreal.index.Index(
-            self.index_path, corpus=corpus, pool=self.pool, mp_context=self.mp_context
-        )
+        return hyperreal.index.Index(self.index_path, corpus=corpus, pool=self.pool)
 
     def list_indices(self):
         return {

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -76,9 +76,10 @@ def test_model_creation(example_index_path, n_clusters):
     index = hyperreal.index.Index(example_index_path)
 
     index.initialise_clusters(n_clusters)
-    index.refine_clusters(iterations=1)
+    index.refine_clusters(iterations=3)
 
-    assert len(index.cluster_ids) == n_clusters == len(index.top_cluster_features())
+    assert len(index.cluster_ids) == len(index.top_cluster_features())
+    assert 1 < len(index.cluster_ids) <= n_clusters
 
 
 def test_model_editing(example_index_path):
@@ -225,18 +226,6 @@ def test_pivoting(example_index_path):
                 break
         else:
             assert False
-
-
-def test_within_cluster_associations(example_index_path):
-    index = hyperreal.index.Index(example_index_path)
-
-    index.initialise_clusters(64, min_docs=3)
-    index.refine_clusters(iterations=3)
-    similarities = index.measure_within_clusters_feature_similarity(min_similarity=0.1)
-
-    for cluster in similarities.values():
-        for sim, f1, f2 in cluster:
-            assert index[f1[0]].jaccard_index(index[f2[0]]) >= 0.1
 
 
 def test_create_new_features(example_index_corpora_path):


### PR DESCRIPTION
We can now migrate to newer versions of the index schema, so (in theory) we can add new feature/functionality without needing to create a whole new index.

The test case for this is to materialise and use the union of documents matched by the features in a cluster as the cluster representative for cluster similarity calculations when pivoting.