### PR TITLE
Refine the clustering algorithm

### DIFF
--- a/hyperreal/cli.py
+++ b/hyperreal/cli.py
@@ -315,6 +315,7 @@ def twittersphere_corpus_serve(corpus_db, index_db):
 @click.option(
     "--clusters",
     default=None,
+    type=click.INT,
     help="The number of clusters to use in the model. "
     "Ignored unless this is the first run, or --restart is passed. "
     "If not provided in those cases it will default to 64. ",

--- a/hyperreal/cli.py
+++ b/hyperreal/cli.py
@@ -314,9 +314,10 @@ def twittersphere_corpus_serve(corpus_db, index_db):
 @click.option("--iterations", default=10)
 @click.option(
     "--clusters",
-    default=64,
+    default=None,
     help="The number of clusters to use in the model. "
-    "Ignored unless this is the first run, or --restart is passed.",
+    "Ignored unless this is the first run, or --restart is passed. "
+    "If not provided in those cases it will default to 64. ",
 )
 @click.option("--min-docs", default=100)
 @click.option(
@@ -353,6 +354,8 @@ def model(
 
     if has_clusters:
         if restart:
+            # If the number of clusters isn't explicitly set.
+            clusters = clusters or 64
             click.echo(
                 f"Restarting new feature cluster model with {clusters} clusters on {index_db}."
             )
@@ -362,6 +365,8 @@ def model(
                 include_fields=include_field or None,
             )
     else:
+        # If the number of clusters isn't explicitly set.
+        clusters = clusters or 64
         click.echo(
             f"Creating new feature cluster model with {clusters} clusters on {index_db}."
         )

--- a/hyperreal/cli.py
+++ b/hyperreal/cli.py
@@ -339,6 +339,13 @@ def twittersphere_corpus_serve(corpus_db, index_db):
 def model(
     index_db, iterations, clusters, min_docs, restart, include_field, random_seed
 ):
+    """
+    Create or refine a new feature cluster model on the given index.
+
+    Note that n_clusters can be changed arbitrarily, even when not initialising a new
+    model with --restart.
+
+    """
     doc_index = hyperreal.index.Index(index_db, random_seed=random_seed)
 
     # Check if any clusters exist.
@@ -365,7 +372,7 @@ def model(
         )
 
     click.echo(f"Refining for {iterations} iterations on {index_db}.")
-    doc_index.refine_clusters(iterations=iterations)
+    doc_index.refine_clusters(iterations=iterations, target_clusters=clusters)
 
 
 @cli.command()

--- a/hyperreal/index.py
+++ b/hyperreal/index.py
@@ -1121,9 +1121,7 @@ class Index:
                 cluster_feature[cluster_id] = set()
 
             if too_small_cluster_ids:
-                logger.info(
-                    f"Dissolving {len(too_small_cluster_ids)} too-small clusters."
-                )
+                logger.info(f"Filling {len(too_small_cluster_ids)} too-small clusters.")
 
             # The logic here is to: split the largest cluster recursively until
             # we have enough clusters. Maybe in the future this could be a split
@@ -1191,7 +1189,7 @@ class Index:
                     )[:n_dissolve]
                 )
                 self.logger.info(
-                    f"Dissolving low objective clusters: {dissolve_cluster_ids}"
+                    f"Dissolving {len(dissolve_cluster_ids)} low objective clusters"
                 )
             else:
                 dissolve_cluster_ids = set()

--- a/hyperreal/server.py
+++ b/hyperreal/server.py
@@ -179,14 +179,19 @@ class ClusterOverview:
         self,
         index_id,
         cluster_id=None,
-        target_clusters="10",
+        target_clusters=None,
         iterations="10",
         return_to="cluster",
         minimum_cluster_features="1",
     ):
+        if target_clusters:
+            target_clusters = int(target_clusters)
+        else:
+            target_clusters = None
+
         cherrypy.request.index.refine_clusters(
             cluster_ids=cherrypy.request.params["cluster_id"],
-            target_clusters=int(target_clusters),
+            target_clusters=target_clusters,
             minimum_cluster_features=int(minimum_cluster_features),
             iterations=int(iterations),
         )
@@ -414,9 +419,13 @@ class Index:
         Refine the existing model for the given number of iterations.
 
         """
+        if target_clusters:
+            target_clusters = int(target_clusters)
+        else:
+            target_clusters = None
         cherrypy.request.index.refine_clusters(
             iterations=int(iterations),
-            target_clusters=int(target_clusters) or None,
+            target_clusters=target_clusters,
             minimum_cluster_features=int(minimum_cluster_features),
         )
 

--- a/hyperreal/templates/index.html
+++ b/hyperreal/templates/index.html
@@ -26,7 +26,7 @@
         </select>
         <input type="hidden" name="return_to" value="model">
         <label for="target_clusters">Refine selection into how many clusters:</label>
-        <input id="target_clusters" name="target_clusters" type="number" value="10" />
+        <input id="target_clusters" name="target_clusters" type="number" />
         <button type="submit" formaction="/index/{{ index_id }}/cluster/refine" method="post">Refine Selected Clusters</button>
         <br>
         <button type="submit">Delete Clusters 🗑️</button>

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -7,6 +7,7 @@ import collections
 import concurrent.futures as cf
 import csv
 import heapq
+import logging
 import multiprocessing as mp
 import pathlib
 import random
@@ -344,6 +345,24 @@ def test_filling_empty_clusters(example_index_path):
     index.refine_clusters(iterations=3, target_clusters=12)
 
     assert len(index.cluster_ids) == 12
+
+
+def test_termination(example_index_path, caplog):
+    """Test"""
+    index = hyperreal.index.Index(example_index_path)
+
+    n_clusters = 8
+    index.initialise_clusters(n_clusters)
+
+    with caplog.at_level(logging.INFO):
+        index.refine_clusters(iterations=100)
+        assert len(index.cluster_ids) == n_clusters
+
+        for record in caplog.records:
+            if "Terminating" in record.message:
+                break
+        else:
+            assert False
 
 
 def test_pinning_features(example_index_path):


### PR DESCRIPTION
Refines the clustering algorithm to enable adjusting the number of clusters *down* as well as the currently supported up, and also to enable future adjustments to the clustering procedure that allow for more than just feature-cluster moves. This also drops the sub_iteration between partial batches of the whole feature set, and replaces it with probabilistic acceptance of moves that improve the clustering.

Unlike the old procedure which proceeded in two phases of group testing for possible candidate moves, then individual cluster testing within each group, this approach now takes four phases:

1. Test each feature's contribution to its own cluster, and calculate the cluster objective.*
2. Test adding each feature to groups of clusters, other than the group it's assigned to on that iteration.
3. Test each feature against individual clusters in the best scoring group.
4. Accept feature moves with only a certain probability, instead of only moving partial sets of features on each sub_iteration. If there are many possible moves for a feature that improve the objective a move is more likely.

The first phase is the most critical, as it allows evaluation of cluster objective scores *before* working out feature moves. This enables the functionality to slowly dissolve clusters that contribute little to the overall objective.

I haven't systematically evaluated this but it also seems to lead to improved numerical scores of the overall objective, while only taking slightly more time than the current approach.

Outstanding issues:

- Currently this makes the algorithm non-deterministic, unless only a single process is used for the worker pool.