### PR TITLE
Workflow refinements

### DIFF
--- a/hyperreal/cli.py
+++ b/hyperreal/cli.py
@@ -355,6 +355,11 @@ def model(
 
     if has_clusters:
         if restart:
+            click.confirm(
+                "A model already exists on this index, do you want to delete it?",
+                abort=True,
+            )
+
             # If the number of clusters isn't explicitly set.
             clusters = clusters or 64
             click.echo(

--- a/hyperreal/cli.py
+++ b/hyperreal/cli.py
@@ -334,8 +334,8 @@ def twittersphere_corpus_serve(corpus_db, index_db):
 )
 @click.option(
     "--tolerance",
-    default=0,
-    type=float,
+    default=0.01,
+    type=click.FloatRange(0, 1),
     help="Specify an early termination tolerance on the fraction of features moving. "
     "If fewer than this fraction of features moves in an iteration, the "
     "refinement will terminate early.",

--- a/hyperreal/cli.py
+++ b/hyperreal/cli.py
@@ -333,13 +333,28 @@ def twittersphere_corpus_serve(corpus_db, index_db):
     "--restart", default=False, is_flag=True, help="Restart the model from scratch."
 )
 @click.option(
+    "--tolerance",
+    default=0,
+    type=float,
+    help="Specify an early termination tolerance on the fraction of features moving. "
+    "If fewer than this fraction of features moves in an iteration, the "
+    "refinement will terminate early.",
+)
+@click.option(
     "--random-seed",
     default=None,
     type=int,
     help="Specify a random seed for a model run. Best used with restart",
 )
 def model(
-    index_db, iterations, clusters, min_docs, restart, include_field, random_seed
+    index_db,
+    iterations,
+    clusters,
+    min_docs,
+    restart,
+    include_field,
+    random_seed,
+    tolerance,
 ):
     """
     Create or refine a new feature cluster model on the given index.
@@ -383,7 +398,9 @@ def model(
         )
 
     click.echo(f"Refining for {iterations} iterations on {index_db}.")
-    doc_index.refine_clusters(iterations=iterations, target_clusters=clusters)
+    doc_index.refine_clusters(
+        iterations=iterations, target_clusters=clusters, tolerance=tolerance
+    )
 
 
 @cli.command()

--- a/hyperreal/index.py
+++ b/hyperreal/index.py
@@ -1344,6 +1344,7 @@ class Index:
         cluster_ids: Optional[Sequence[int]] = None,
         target_clusters: Optional[int] = None,
         minimum_cluster_features: int = 1,
+        tolerance: float = 0.01,
     ):
         """
         Refine the feature clusters for the current model.
@@ -1408,6 +1409,7 @@ class Index:
             pinned_features=pinned_features,
             minimum_cluster_features=minimum_cluster_features,
             max_clusters=target_clusters,
+            tolerance=tolerance,
         )
 
         # Serialise the actual results of the clustering!

--- a/hyperreal/index.py
+++ b/hyperreal/index.py
@@ -1065,7 +1065,6 @@ class Index:
 
         # Used to determine the size of newly sampled clusters when filling in
         # too-small clusters.
-        self.logger.info(f"{len(movable_features)}, {2 * max_clusters}")
         sample_cluster_size = max(
             minimum_cluster_features, len(movable_features) // (2 * max_clusters)
         )
@@ -1075,7 +1074,7 @@ class Index:
         assigned_cluster_ids = set(cluster_feature)
 
         # Work out how many low objective clusters to dissolve on each iteration.
-        dissolve_clusters = len(assigned_cluster_ids) - max_clusters
+        dissolve_clusters = max(0, len(assigned_cluster_ids) - max_clusters)
         # Note that we try to structure it so the very last iteration does not dissolve
         # anything.
         dissolve_per_iteration = math.ceil(dissolve_clusters / max(1, iterations - 1))
@@ -1398,8 +1397,9 @@ class Index:
         # Remove pinned clusters from refinement. Note we do this after
         # creating empty clusters because a pinned cluster still needs to be
         # counted.
-        for cluster_id in self.pinned_cluster_ids:
-            del cluster_feature[cluster_id]
+        pinned_clusters = self.pinned_cluster_ids
+        for cluster_id in pinned_clusters:
+            cluster_feature.pop(cluster_id, None)
 
         cluster_feature = self._refine_feature_groups(
             cluster_feature,

--- a/hyperreal/index.py
+++ b/hyperreal/index.py
@@ -833,6 +833,15 @@ class Index:
             )
         ]
 
+    @property
+    def pinned_cluster_ids(self):
+        return {
+            r[0]
+            for r in self.db.execute(
+                "select cluster_id from cluster where pinned order by cluster_id"
+            )
+        }
+
     @atomic()
     def top_cluster_features(self, top_k=20):
         """Return the top_k features according to the number of matching documents."""
@@ -1375,11 +1384,7 @@ class Index:
         # Remove pinned clusters from refinement. Note we do this after
         # creating empty clusters because a pinned cluster still needs to be
         # counted.
-        pinned_clusters = {
-            r[0] for r in self.db.execute("select cluster_id from cluster where pinned")
-        }
-
-        for cluster_id in pinned_clusters:
+        for cluster_id in self.pinned_cluster_ids:
             del cluster_feature[cluster_id]
 
         cluster_feature = self._refine_feature_groups(

--- a/hyperreal/index.py
+++ b/hyperreal/index.py
@@ -877,7 +877,12 @@ class Index:
 
         """
 
-        cluster_ids = cluster_ids or self.cluster_ids
+        cluster_ids = cluster_ids or [
+            r[0]
+            for r in self.db.execute(
+                "select cluster_id from cluster order by feature_count desc"
+            )
+        ]
 
         if scoring == "jaccard":
             work = [
@@ -886,6 +891,7 @@ class Index:
             pivoted = (
                 r for r in self.pool.map(_pivot_cluster_by_query_jaccard, work) if r[1]
             )
+
         elif scoring == "chi_squared":
             N = list(self.db.execute("select count(*) from doc_key"))[0][0]
             work = [

--- a/hyperreal/server.py
+++ b/hyperreal/server.py
@@ -161,7 +161,7 @@ class ClusterOverview:
     @cherrypy.expose
     @cherrypy.tools.allow(methods=["POST"])
     @cherrypy.tools.ensure_list(feature_id=int)
-    def create(self, index_id, feature_id=None):
+    def create(self, index_id, feature_id=None, **params):
         new_cluster_id = cherrypy.request.index.create_cluster_from_features(
             cherrypy.request.params["feature_id"]
         )

--- a/hyperreal/server.py
+++ b/hyperreal/server.py
@@ -85,16 +85,13 @@ class Cluster:
         if feature_id is not None:
             feature_id = int(feature_id)
             query = cherrypy.request.index[feature_id]
-            print(len(query))
 
         if filter_cluster_id is not None:
             filter_cluster_id = int(filter_cluster_id)
             if query:
                 query &= cherrypy.request.index.cluster_docs(filter_cluster_id)
-                print(len(query))
             else:
                 query = cherrypy.request.index.cluster_docs(filter_cluster_id)
-                print(len(query))
 
         if query:
             sorted_features = cherrypy.request.index.pivot_clusters_by_query(
@@ -123,6 +120,8 @@ class Cluster:
 
         total_docs = len(retrieve_docs)
 
+        pinned = int(cluster_id in cherrypy.request.index.pinned_cluster_ids)
+
         return template.render(
             cluster_id=cluster_id,
             highlight_feature_id=feature_id,
@@ -133,6 +132,7 @@ class Cluster:
             total_docs=total_docs,
             prev_cluster_id=prev_cluster_id,
             next_cluster_id=next_cluster_id,
+            pinned=pinned,
         )
 
 

--- a/hyperreal/server.py
+++ b/hyperreal/server.py
@@ -4,6 +4,7 @@ Cherrypy based webserver for serving an index (or in future) a set of indexes.
 """
 import csv
 import io
+import math
 import os
 from urllib.parse import parse_qsl
 
@@ -11,7 +12,6 @@ import cherrypy
 from jinja2 import PackageLoader, Environment, select_autoescape
 
 import hyperreal.index
-import hyperreal.utilities
 
 
 templates = Environment(
@@ -272,7 +272,7 @@ class Index:
         feature_id=None,
         cluster_id=None,
         exemplar_docs="5",
-        top_k_features="20",
+        top_k_features="40",
         scoring="jaccard",
     ):
         template = templates.get_template("index.html")
@@ -301,15 +301,14 @@ class Index:
             highlight_feature_id = int(feature_id)
 
         elif cluster_id is not None:
-            query, bitslice = cherrypy.request.index.cluster_query(int(cluster_id))
+            query = cherrypy.request.index.cluster_docs(int(cluster_id))
             clusters = cherrypy.request.index.pivot_clusters_by_query(
                 query, scoring=scoring, top_k=int(top_k_features)
             )
 
             if cherrypy.request.index.corpus is not None:
-                ranked = hyperreal.utilities.bstm(query, bitslice, int(exemplar_docs))
                 rendered_docs = cherrypy.request.index.render_docs(
-                    ranked, random_sample_size=int(exemplar_docs)
+                    query, random_sample_size=int(exemplar_docs)
                 )
 
             total_docs = len(query)

--- a/hyperreal/templates/base.html
+++ b/hyperreal/templates/base.html
@@ -36,7 +36,7 @@ body {
 
 .cluster-list li {
     padding-left: 0;
-    background: #f0f0f0;
+    background: #f6f6f6;
 }
 
 .compact-cluster {

--- a/hyperreal/templates/base.html
+++ b/hyperreal/templates/base.html
@@ -9,18 +9,24 @@
 
     <style type="text/css">
 
+body {
+    margin: 0 1em;
+}
+
 .cluster-list {
     display: flex;
     flex-wrap: wrap;
     list-style-type: none;
-    padding-left: 0;
+    padding: 0;
+    margin: 0 -0.5em;
 }
 
 .cluster-list > li {
     flex: 1 1 40ch;
-    margin: 1em;
+    margin: 0.5em;
     box-shadow: 0 0 0.1em 0.1em gray;
     border-radius: 0.4em;
+    justify-content: space-between;
 }
 
 .highlight {
@@ -30,35 +36,39 @@
 
 .cluster-list li {
     padding-left: 0;
-    background: #f6f6f6;
+    background: #f0f0f0;
 }
 
 .compact-cluster {
     max-width: 80em;
-    margin: 1em;
-    padding: 0.5em;
-    padding-left: 0;
+    margin: 0.25em;
+    padding: 0;
 }
 
 .compact-cluster li {
     display: inline-block;
     list-style-type: none;
     margin: 0.25em;
-    padding-left: 0;
+    padding: 0;
+}
+
+.cluster-footer {
+    margin: 1em 0.5em;
 }
 
 .cluster-header {
     background: black;
     color: white;
     border-radius: 0.4em 0.4em 0 0;
+    padding: 0 0.5em;
 }
 
 .doc-list {
-    padding-left: 0;
+    padding: 0;
 }
+
 .doc-list > li{
-    margin: 1em;
-    border-left: 0.5em solid grey;
+    margin: 0.75em 0.5em;
     background-color: white;
     list-style-type: none;
     padding: 0.5em;

--- a/hyperreal/templates/base.html
+++ b/hyperreal/templates/base.html
@@ -41,15 +41,21 @@ body {
 
 .compact-cluster {
     max-width: 80em;
-    margin: 0.25em;
+    margin: 0.5em;
     padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
 }
 
 .compact-cluster li {
-    display: inline-block;
     list-style-type: none;
-    margin: 0.25em;
+    margin: 0.375em;
     padding: 0;
+}
+
+.compact-cluster li:last-of-type {
+    margin-right: auto;
 }
 
 .cluster-footer {

--- a/hyperreal/templates/base.html
+++ b/hyperreal/templates/base.html
@@ -10,23 +10,27 @@
     <style type="text/css">
 
 .cluster-list {
-    display: inline-block;
+    display: flex;
+    flex-wrap: wrap;
     list-style-type: none;
     padding-left: 0;
-    max-width: 80em;
 }
 
 .cluster-list > li {
-    margin: 2em 1em;
-    box-shadow: 0 0 0.2em 0.1em gray;
+    flex: 1 1 40ch;
+    margin: 1em;
+    box-shadow: 0 0 0.1em 0.1em gray;
+    border-radius: 0.4em;
 }
 
 .highlight {
     border: 0.2em solid orange;
+    border-radius: 0.4em;
 }
 
 .cluster-list li {
     padding-left: 0;
+    background: #f6f6f6;
 }
 
 .compact-cluster {
@@ -46,9 +50,8 @@
 .cluster-header {
     background: black;
     color: white;
+    border-radius: 0.4em 0.4em 0 0;
 }
-
-.feature-link { text-decoration: none; }
 
 .doc-list {
     padding-left: 0;
@@ -56,10 +59,10 @@
 .doc-list > li{
     margin: 1em;
     border-left: 0.5em solid grey;
-    background-color: #eee;
+    background-color: white;
     list-style-type: none;
     padding: 0.5em;
-
+    border-radius: 0.4em;
 }
 
 img {
@@ -67,26 +70,39 @@ img {
 }
 
 .feature {
-  border: 0.1em solid black;
-  border-radius: 0.2em;
-  display: inline-block;
-  margin: 0 0.5em;
+    position: relative;
+    box-shadow: 0.05em 0.05em 0.05em 0.05em gray;
+    border-radius: 0.4em;
+    display: inline-block;
+    margin: 0;
+    min-width: 4.5ch;
+    background: white;
+
 }
 
 .field {
-  background: black;
-  color: white;
-  height:  100%;
-  padding: 0 0.5em;
+    position: absolute;
+    left: 0.1em;
+    top: 0.1em;
+    color: black;
+    padding: 0.1em;
+    margin: 0;
+    font-size: 50%;
 }
 
 .value {
-    padding: 0 0.5em;
+    padding: 0.75em 0.5em;
+    text-align: center;
 }
 
 .score {
     color: black;
-    font-size: 60%;
+    font-size: 50%;
+    padding: 0.1em;
+    position: absolute;
+    right: 0.1em;
+    bottom: 0.1em;
+    display: table-cell;
 }
 
 table {
@@ -99,7 +115,7 @@ thead {
     border-bottom: 0.1em solid black;
 }
 
-tbody > tr:nth-child(odd) {background: #eee}
+tbody > tr:nth-child(odd) {background: #f6f6f6}
 
 th {
     padding: 0.5em;

--- a/hyperreal/templates/base.html
+++ b/hyperreal/templates/base.html
@@ -34,6 +34,11 @@ body {
     border-radius: 0.4em;
 }
 
+.pinned {
+    border: 0.2em solid blue;
+    border-radius: 0.4em;   
+}
+
 .cluster-list li {
     padding-left: 0;
     background: #f6f6f6;

--- a/hyperreal/templates/base.html
+++ b/hyperreal/templates/base.html
@@ -10,7 +10,7 @@
     <style type="text/css">
 
 body {
-    margin: 0 1em;
+    margin: 0 3em;
 }
 
 .cluster-list {
@@ -23,7 +23,7 @@ body {
 
 .cluster-list > li {
     flex: 1 1 40ch;
-    margin: 0.5em;
+    margin: 1em 0.5em;
     box-shadow: 0 0 0.1em 0.1em gray;
     border-radius: 0.4em;
     justify-content: space-between;
@@ -41,7 +41,7 @@ body {
 
 .compact-cluster {
     max-width: 80em;
-    margin: 0.5em;
+    margin: 0.25em;
     padding: 0;
     display: flex;
     flex-wrap: wrap;
@@ -49,8 +49,9 @@ body {
 }
 
 .compact-cluster li {
+    display: inline-block;
     list-style-type: none;
-    margin: 0.375em;
+    margin: 0.25em;
     padding: 0;
 }
 
@@ -91,6 +92,7 @@ img {
     border-radius: 0.4em;
     display: inline-block;
     margin: 0;
+    margin-bottom: 0.5em;
     min-width: 4.5ch;
     background: white;
 
@@ -151,6 +153,28 @@ form {
     max-width: 80em;
 }
 
+.nav-links {
+    display: flex;
+    list-style-type: none;
+    margin-bottom: 1em;
+    margin-top: 0em;
+    padding-left: 0;
+}
+
+.nav-links li {
+    margin-right: 1em;
+}
+
+nav, h1 {
+    display: inline-block;
+}
+
+h1 {
+    margin-bottom: 1rem;
+    margin-right: 1rem;
+}
+
+
     </style>
 
     {% block meta %}
@@ -161,10 +185,10 @@ form {
     <header>
         <h1><a href="/">Feature Clustering</a></h1>
         <nav>
-        <ul>
-        {% block nav %}
-        {% endblock %}
-        </ul>
+            <ul class="nav-links">
+            {% block nav %}
+            {% endblock %}
+            </ul>
         </nav>
     </header>
     <main>{% block content %}{% endblock %}</main>

--- a/hyperreal/templates/cluster.html
+++ b/hyperreal/templates/cluster.html
@@ -12,6 +12,14 @@
 
 {% block content %}
 
+{% if prev_cluster_id or next_cluster_id %}
+<ul class="nav-links">
+    <li><a href="/index/{{ index_id }}/cluster/{{ prev_cluster_id }}">Previous Cluster</li>
+    <li><a href="/index/{{ index_id }}/cluster/{{ next_cluster_id }}">Next Cluster</li>
+    <li><a href="/index/{{ index_id }}/?cluster_id={{ cluster_id }}">Pivot By Cluster</a></li>
+</ul>
+{% endif %}
+
 <details>
     <summary>Edit this cluster</summary>
 
@@ -69,14 +77,6 @@
     </form>
 </details>
 
-
-{% if prev_cluster_id or next_cluster_id %}
-<ul>
-    <li><a href="/index/{{ index_id }}/cluster/{{ prev_cluster_id }}">Previous Cluster</li>
-    <li><a href="/index/{{ index_id }}/cluster/{{ next_cluster_id }}">Next Cluster</li>
-    <li><a href="/index/{{ index_id }}/?cluster_id={{ cluster_id }}">Pivot By Cluster</a></li>
-</ul>
-{% endif %}
 <ul class="cluster-list">
     <li>
         {{ render_cluster(index_id, cluster_id, features, highlight_feature_id=highlight_feature_id, context="cluster") }}

--- a/hyperreal/templates/cluster.html
+++ b/hyperreal/templates/cluster.html
@@ -7,22 +7,33 @@
 {% block nav %}
     <li><a href="/index/{{ index_id }}/details">Index Details</a></li>
     <li><a href="/index/{{ index_id }}">Model Overview</a></li>
-    <li><a href="/index/{{ index_id }}/cluster/{{ cluster_id }}">Cluster Overview</a></li>
 {% endblock %}
 
 {% block content %}
 
-{% if prev_cluster_id or next_cluster_id %}
 <ul class="nav-links">
+    <li><a href="/index/{{ index_id }}/cluster/{{ cluster_id }}">Cluster Overview</a></li>
+    {% if prev_cluster_id or next_cluster_id %}
     <li><a href="/index/{{ index_id }}/cluster/{{ prev_cluster_id }}">Previous Cluster</li>
     <li><a href="/index/{{ index_id }}/cluster/{{ next_cluster_id }}">Next Cluster</li>
+    {% endif %}
     <li><a href="/index/{{ index_id }}/?cluster_id={{ cluster_id }}">Pivot By Cluster</a></li>
 </ul>
-{% endif %}
 
 <details>
     <summary>Edit this cluster</summary>
 
+    {% if pinned %}
+    <form method="post" action="/index/{{ index_id }}/cluster/pin">
+        <fieldset>
+            <input type="hidden" name="return_to" value="cluster">
+            <input type="hidden" name="cluster_id" value="{{ cluster_id }}">
+            <input type="hidden" name="pinned" value="{{ 0 if pinned else 1 }}">
+            <button class="inline-button" type="submit">Unpin Cluster</button>
+        </fieldset>
+    </form>
+
+    {% else %}
     <form method="post" action="/index/{{ index_id }}/feature/remove_from_model">
         <fieldset>
             <label for="feature_selection">Choose features:</label>
@@ -61,18 +72,9 @@
             <input type="hidden" name="return_to" value="cluster">
             <input type="hidden" name="cluster_id" value="{{ cluster_id }}">
             <input type="hidden" name="pinned" value="{{ 0 if pinned else 1 }}">
-            <button class="inline-button" type="submit">{{ 'Unpin cluster' if pinned else 'Pin cluster'}}</button>
+            <button class="inline-button" type="submit">Pin Cluster</button>
         </fieldset>
     </form>
-
-    {% if visible_features %}
-    <form method="post" action="/index/{{ index_id }}/cluster/create">
-        {% for feature_id in visible_features %}
-        <input type="hidden" name="feature_id" value={{ feature_id }}>
-        {% endfor %}
-        <button type="submit">Create New Cluster From All Visible Features</button>
-    </form>
-    {% endif %}
 
     <form method="post" action="/index/{{ index_id }}/cluster/refine">
         <fieldset>
@@ -95,6 +97,8 @@
         </fieldset>
         <button type="submit">Split Cluster</button>
     </form>
+
+    {% endif %}
 </details>
 
 <ul class="cluster-list">

--- a/hyperreal/templates/cluster.html
+++ b/hyperreal/templates/cluster.html
@@ -84,7 +84,9 @@
 
     {% if rendered_docs %}
     <li>
-        <p>{% if rendered_docs|length < total_docs %}Sample of the {{ total_docs }} matching documents.{% else %}All {{ total_docs }} matching documents.{% endif %}</p>
+        <div class="cluster-header">
+            {% if rendered_docs|length < total_docs %}Sample of {{ total_docs }} documents{% else %}All {{ total_docs }} matching documents.{% endif %}
+        </div>
         <ul class="doc-list">
             {% for doc_id, doc in rendered_docs %}
             <li>{{ doc }}</li>

--- a/hyperreal/templates/cluster.html
+++ b/hyperreal/templates/cluster.html
@@ -37,6 +37,15 @@
         </fieldset>
     </form>
 
+    <form method="post" action="/index/{{ index_id }}/cluster/pin">
+        <fieldset>
+            <input type="hidden" name="return_to" value="cluster">
+            <input type="hidden" name="cluster_id" value="{{ cluster_id }}">
+            <input type="hidden" name="pinned" value="{{ 0 if pinned else 1 }}">
+            <button class="inline-button" type="submit">{{ 'Unpin cluster' if pinned else 'Pin cluster'}}</button>
+        </fieldset>
+    </form>
+
     <form method="post" action="/index/{{ index_id }}/cluster/refine">
         <fieldset>
             <input type="hidden" name="cluster_id" value="{{ cluster_id }}">

--- a/hyperreal/templates/cluster.html
+++ b/hyperreal/templates/cluster.html
@@ -45,6 +45,17 @@
         </fieldset>
     </form>
 
+    {% if visible_features %}
+    <form method="post" action="/index/{{ index_id }}/cluster/create">
+        <fieldset>
+            {% for feature_id in visible_features %}
+            <input type="hidden" name="feature_id" value={{ feature_id }}>
+            {% endfor %}
+            <button type="submit">Create New Cluster From All Visible Features</button>
+        </fieldset>
+    </form>
+    {% endif %}
+
     <form method="post" action="/index/{{ index_id }}/cluster/pin">
         <fieldset>
             <input type="hidden" name="return_to" value="cluster">
@@ -53,6 +64,15 @@
             <button class="inline-button" type="submit">{{ 'Unpin cluster' if pinned else 'Pin cluster'}}</button>
         </fieldset>
     </form>
+
+    {% if visible_features %}
+    <form method="post" action="/index/{{ index_id }}/cluster/create">
+        {% for feature_id in visible_features %}
+        <input type="hidden" name="feature_id" value={{ feature_id }}>
+        {% endfor %}
+        <button type="submit">Create New Cluster From All Visible Features</button>
+    </form>
+    {% endif %}
 
     <form method="post" action="/index/{{ index_id }}/cluster/refine">
         <fieldset>

--- a/hyperreal/templates/index.html
+++ b/hyperreal/templates/index.html
@@ -45,7 +45,7 @@
     {% if rendered_docs %}
     <li>
         <div class="cluster-header">
-            {% if rendered_docs|length < total_docs %}Random sample of {{ total_docs }} matching documents.{% else %}All {{ total_docs }} matching documents.{% endif %}
+            {% if rendered_docs|length < total_docs %}Sample of {{ total_docs }} documents{% else %}All {{ total_docs }} matching documents.{% endif %}
         </div>
         <ul class="doc-list">
             {% for doc_id, doc in rendered_docs %}

--- a/hyperreal/templates/index.html
+++ b/hyperreal/templates/index.html
@@ -44,7 +44,9 @@
 
     {% if rendered_docs %}
     <li>
-        <p>{% if rendered_docs|length < total_docs %}Sample of the {{ total_docs }} top matching documents.{% else %}All {{ total_docs }} matching documents.{% endif %}</p>
+        <div class="cluster-header">
+            {% if rendered_docs|length < total_docs %}Random sample of {{ total_docs }} matching documents.{% else %}All {{ total_docs }} matching documents.{% endif %}
+        </div>
         <ul class="doc-list">
             {% for doc_id, doc in rendered_docs %}
             <li>{{ doc }}</li>

--- a/hyperreal/templates/index.html
+++ b/hyperreal/templates/index.html
@@ -32,6 +32,15 @@
         <button type="submit">Delete Clusters 🗑️</button>
         <button type="submit" formaction="/index/{{ index_id }}/cluster/merge" method="post">Merge Clusters</button>
     </form>
+
+    {% if visible_features %}
+    <form method="post" action="/index/{{ index_id }}/cluster/create">
+        {% for feature_id in visible_features %}
+        <input type="hidden" name="feature_id" value={{ feature_id }}>
+        {% endfor %}
+        <button type="submit">Create New Cluster From All Visible Features</button>
+    </form>
+    {% endif %}
 </details>
 
 <ul class="cluster-list">

--- a/hyperreal/templates/macros.html
+++ b/hyperreal/templates/macros.html
@@ -1,10 +1,10 @@
 {% macro render_feature(index_id, cluster_id, feature_id, field, value, score, context, highlight_feature_id=None) %}
 <div {% if feature_id == highlight_feature_id %}class="highlight"{% endif %}>
-    <a class="feature-link" href="/index/{{ index_id }}/{{ 'cluster/{}/'.format(cluster_id) if context =='cluster' }}?feature_id={{ feature_id }}">
+    <a href="/index/{{ index_id }}/{{ 'cluster/{}/'.format(cluster_id) if context =='cluster' }}?feature_id={{ feature_id }}">
         <div class="feature">
             <span class="field">{{ field }}</span>
-            <span class="value">{{ value }}</span>
-            <span class="score">{{ ("{0:0.2f}" if score <= 1.0 else "{0:g}").format(score) }}</span>
+            <div class="value">{{ value }}</div>
+            <span class="score">{{ ("{:.2e}").format(score) }}</span>
         </div>
     </a>
 </div>
@@ -12,9 +12,9 @@
 
 
 {% macro render_cluster(index_id, cluster_id, features, cluster_score=None, highlight_cluster_id=None, highlight_feature_id=None, context='index') -%}
-<div {% if cluster_id == highlight_cluster_id %}class="highlight"{% endif %}>
+<div class="feature-cluster {% if cluster_id == highlight_cluster_id %}highlight{% endif %}">
     <div class="cluster-header">
-        Cluster {{ cluster_id }} {% if cluster_score is not none %}- {{ ("{0:0.2f}" if cluster_score <= 1.0 else "{0:g}").format(cluster_score) }}{% endif %}
+        Cluster {{ cluster_id }} {% if cluster_score is not none %}- {{ "{:.2e}".format(cluster_score) }}{% endif %}
     </div>
     <ul class="compact-cluster">
         {% for feature_id, field, value, score in features %}

--- a/hyperreal/templates/macros.html
+++ b/hyperreal/templates/macros.html
@@ -12,8 +12,8 @@
 
 
 {% macro render_cluster(index_id, cluster_id, features, cluster_score=None, highlight_cluster_id=None, highlight_feature_id=None, context='index') -%}
-<div class="feature-cluster {% if cluster_id == highlight_cluster_id %}highlight{% endif %}">
-    <div class="cluster-header">
+<div class="feature-cluster">
+    <div class="cluster-header {% if cluster_id == highlight_cluster_id %}highlight{% endif %}">
         Cluster {{ cluster_id }} {% if cluster_score is not none %}- {{ "{:.2e}".format(cluster_score) }}{% endif %}
     </div>
     <ul class="compact-cluster">
@@ -22,20 +22,20 @@
             {{ render_feature(index_id, cluster_id, feature_id, field, value, score, context, highlight_feature_id=highlight_feature_id)}}
         </li>
         {% endfor %}
+    </ul>
 
     {% if context == "index" %}
+    <div class="cluster-footer">
         <a href="/index/{{ index_id }}/cluster/{{ cluster_id }}{{ '/?feature_id={}'.format(highlight_feature_id) if highlight_feature_id else '' }}">See all</a>
-    </ul>
-    <a href="/index/{{ index_id }}/?cluster_id={{ cluster_id }}">Pivot</a>
-    <details>
-        <summary>Edit</summary>
-        <form method="post" action="/index/{{ index_id }}/cluster/delete">
-            <input type="hidden" name="cluster_id" value="{{ cluster_id }}">
-            <button class="inline-button" type="submit">Delete 🗑️</button>
-        </form>
-    </details>
-    {% else %}
-    </ul>
+        <a href="/index/{{ index_id }}/?cluster_id={{ cluster_id }}">Pivot</a>
+        <details>
+            <summary>Edit</summary>
+            <form method="post" action="/index/{{ index_id }}/cluster/delete">
+                <input type="hidden" name="cluster_id" value="{{ cluster_id }}">
+                <button class="inline-button" type="submit">Delete 🗑️</button>
+            </form>
+        </details>
+    </div>
     {% endif %}
 </div>
 {%- endmacro %}

--- a/hyperreal/templates/macros.html
+++ b/hyperreal/templates/macros.html
@@ -1,9 +1,9 @@
 {% macro render_feature(index_id, cluster_id, feature_id, field, value, score, context, highlight_feature_id=None) %}
-<div {% if feature_id == highlight_feature_id %}class="highlight"{% endif %}>
+<div>
     <a href="/index/{{ index_id }}/{{ 'cluster/{}/'.format(cluster_id) if context =='cluster' }}?feature_id={{ feature_id }}">
         <div class="feature">
             <span class="field">{{ field }}</span>
-            <div class="value">{{ value }}</div>
+            <div class="value{% if feature_id == highlight_feature_id %} highlight{% endif %}">{{ value }}</div>
             <span class="score">{{ ("{:.2e}").format(score) }}</span>
         </div>
     </a>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,7 +49,16 @@ def test_plaintext_corpus(tmp_path):
 
     # Model
     result = runner.invoke(
-        cli.model, ["--iterations", "10", "--clusters", "10", str(target_index_db)]
+        cli.model,
+        [
+            "--iterations",
+            "10",
+            "--clusters",
+            "10",
+            "--min-docs",
+            "10",
+            str(target_index_db),
+        ],
     )
 
 
@@ -80,7 +89,16 @@ def test_twittersphere_corpus(tmp_path):
 
     # Model
     result = runner.invoke(
-        cli.model, ["--iterations", "10", "--clusters", "10", str(target_index_db)]
+        cli.model,
+        [
+            "--iterations",
+            "10",
+            "--clusters",
+            "10",
+            "--min-docs",
+            "10",
+            str(target_index_db),
+        ],
     )
 
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -376,12 +376,12 @@ def test_termination(example_index_path, caplog, pool):
             assert False
 
 
-def test_pinning_features(example_index_path, pool):
+def test_pinning(example_index_path, pool):
     """Test expanding the number of clusters by subdividing the largest."""
     index = hyperreal.index.Index(example_index_path, pool=pool)
 
     n_clusters = 8
-    index.initialise_clusters(n_clusters)
+    index.initialise_clusters(n_clusters, min_docs=5)
     index.refine_clusters(iterations=1)
     assert len(index.cluster_ids) == n_clusters
 
@@ -403,3 +403,4 @@ def test_pinning_features(example_index_path, pool):
     index.refine_clusters(iterations=3, target_clusters=16)
 
     assert whole_cluster == {f[0] for f in index.cluster_features(1)}
+    assert len(index.cluster_ids) == 16


### PR DESCRIPTION
An accumulation of small tweaks based on working through a specific detailed analysis.

# Workflow

- Allow pinning and unpinning clusters
- Don't allow editing of pinned clusters - they need to be unpinned first
- Button to grab all visible features into a new cluster for cluster and model views
- Require confirmation in the CLI to recreate a model

# Style improvements

- More compact layout with more features visible on screen - use more of the available space
- Improved some contrast and style elements for the feature view

# Algorithmic Improvements

- Fill empty clusters by sampling from the whole model for more serendipitous improvements
- Simplify the assignment - it turns out that the group randomisation is enough, we can be greedier. A small chance of rejection of good moves is retained to ensure the model doesn't oscillate between the same two states.
- Termination tolerance is now only based on the number of features moved: the number of still moving features is more important for the actual post-computation analysis.
