### PR TITLE
Flat and approximate positions index

### DIFF
--- a/hyperreal/_index_schema.py
+++ b/hyperreal/_index_schema.py
@@ -38,9 +38,29 @@ CURRENT_SCHEMA = f"""
     create table if not exists position_doc (
         field,
         position_end,
+        position_count integer,
         doc_id integer references doc_key(doc_id) on delete cascade,
         primary key (field, position_end)
     ) without rowid;
+
+    --------
+    create table if not exists position_doc (
+        field,
+        position_end,
+        position_count integer,
+        doc_id integer references doc_key(doc_id) on delete cascade,
+        primary key (field, position_end)
+    ) without rowid;
+
+    --------
+    create index if not exists doc_position on position_doc(
+        doc_id,
+        field,
+        position_end,
+        -- Note we materialise this column so this can
+        -- always be used as a covering index.
+        position_count
+    );
 
     --------
     create table if not exists field_summary (

--- a/hyperreal/_index_schema.py
+++ b/hyperreal/_index_schema.py
@@ -17,6 +17,16 @@ MAGIC_APPLICATION_ID = 715973853
 CURRENT_SCHEMA_VERSION = 9
 
 CURRENT_SCHEMA = f"""
+    create table if not exists settings (
+        key primary key,
+        value
+    );
+
+    --------
+    -- Migrated indexes will have no position information.
+    replace into settings values('position_window_size', 0);
+
+    --------
     create table if not exists doc_key (
         doc_id integer primary key,
         doc_key unique
@@ -37,26 +47,17 @@ CURRENT_SCHEMA = f"""
     --------
     create table if not exists position_doc (
         field,
-        position_end,
+        position_start,
         position_count integer,
         doc_id integer references doc_key(doc_id) on delete cascade,
-        primary key (field, position_end)
-    ) without rowid;
-
-    --------
-    create table if not exists position_doc (
-        field,
-        position_end,
-        position_count integer,
-        doc_id integer references doc_key(doc_id) on delete cascade,
-        primary key (field, position_end)
+        primary key (field, position_start)
     ) without rowid;
 
     --------
     create index if not exists doc_position on position_doc(
         doc_id,
         field,
-        position_end,
+        position_start,
         -- Note we materialise this column so this can
         -- always be used as a covering index.
         position_count

--- a/hyperreal/_index_schema.py
+++ b/hyperreal/_index_schema.py
@@ -14,7 +14,7 @@ database, associated with CURRENT_SCHEMA_VERSION.
 # The application ID uses SQLite's pragma application_id to quickly identify index
 # databases from everything else.
 MAGIC_APPLICATION_ID = 715973853
-CURRENT_SCHEMA_VERSION = 8
+CURRENT_SCHEMA_VERSION = 9
 
 CURRENT_SCHEMA = f"""
     create table if not exists doc_key (
@@ -29,8 +29,18 @@ CURRENT_SCHEMA = f"""
         value not null,
         docs_count integer not null,
         doc_ids roaring_bitmap not null,
+        position_count integer,
+        positions roaring_bitmap,
         unique (field, value)
     );
+
+    --------
+    create table if not exists position_doc (
+        field,
+        position_end,
+        doc_id integer references doc_key(doc_id) on delete cascade,
+        primary key (field, position_end)
+    ) without rowid;
 
     --------
     create table if not exists field_summary (
@@ -161,6 +171,13 @@ migrations = {
         [
             "alter table cluster add column pinned bool default 0",
             "alter table feature_cluster add column pinned bool default 0",
+        ],
+        [],
+    ),
+    8: (
+        [
+            "alter table inverted_index add column position_count integer",
+            "alter table inverted_index add column positions roaring_bitmap",
         ],
         [],
     ),

--- a/hyperreal/cli.py
+++ b/hyperreal/cli.py
@@ -68,11 +68,15 @@ def make_two_file_indexer(CorpusType):
         "--position-window-size",
         default=0,
         type=int,
-        help="The window size to record approximate positional information. "
-        "The default 0 disables recording this information. When not zero, "
-        "overlapping windows of size window*2 approximates positions are recorded. "
-        "This can be used for proximity queries. Smaller values require more space, but "
-        "enable precise querying.",
+        help="""
+        The window size to record approximate positional information. The
+        default value of 0 disables recording this information. When > 0,
+        approximate positions of values are recorded up to the given
+        granularity. Smaller values require more space, but enable precise
+        querying. Setting position size to 1 enables recording of exact term
+        positions and precise querying for phrases, but currently only 2**32
+        positions can be recorded in a single field.
+        """,
     )
     def corpus_indexer(corpus_db, index_db, doc_batch_size, position_window_size):
         """
@@ -88,8 +92,6 @@ def make_two_file_indexer(CorpusType):
         mp_context = mp.get_context("spawn")
         with cf.ProcessPoolExecutor(mp_context=mp_context) as pool:
             doc_index = hyperreal.index.Index(index_db, corpus=doc_corpus, pool=pool)
-
-            click.echo(f"{position_window_size=}")
 
             doc_index.index(
                 doc_batch_size=doc_batch_size, position_window_size=position_window_size

--- a/hyperreal/cli.py
+++ b/hyperreal/cli.py
@@ -84,11 +84,16 @@ def make_two_file_indexer(CorpusType):
         click.echo(f"Indexing {corpus_db} into {index_db}.")
 
         doc_corpus = CorpusType(corpus_db)
-        doc_index = hyperreal.index.Index(index_db, corpus=doc_corpus)
 
-        doc_index.index(
-            doc_batch_size=doc_batch_size, position_window_size=position_window_size
-        )
+        mp_context = mp.get_context("spawn")
+        with cf.ProcessPoolExecutor(mp_context=mp_context) as pool:
+            doc_index = hyperreal.index.Index(index_db, corpus=doc_corpus, pool=pool)
+
+            click.echo(f"{position_window_size=}")
+
+            doc_index.index(
+                doc_batch_size=doc_batch_size, position_window_size=position_window_size
+            )
 
     return corpus_indexer
 

--- a/hyperreal/corpus.py
+++ b/hyperreal/corpus.py
@@ -696,13 +696,13 @@ class StackExchangeCorpus(SqliteBackedCorpus):
             )
         )[0]
 
-        tags = [
+        tags = {
             r["Tag"]
             for r in self.db.execute(
                 "select Tag from PostTag where (site_id, PostId) = (:site_id, :TagPostId)",
                 base_fields,
             )
-        ]
+        }
 
         user_comments = list(
             self.db.execute(
@@ -813,7 +813,7 @@ class StackExchangeCorpus(SqliteBackedCorpus):
             # Don't bother indexing at minute/hour granularity - just day/month/year
             if granularity in ("minute", "hour"):
                 continue
-            indexed[f"created_{granularity}"] = [dt.isoformat()]
+            indexed[f"created_{granularity}"] = set([dt.isoformat()])
 
         return indexed
 

--- a/hyperreal/db_utilities.py
+++ b/hyperreal/db_utilities.py
@@ -28,6 +28,7 @@ def connect_sqlite(db_path, row_factory=None):
     )
 
     conn.create_aggregate("roaring_union", 1, RoaringUnion)
+    conn.create_aggregate("roaring_shift_union", 2, RoaringShiftUnion)
 
     if row_factory:
         conn.row_factory = row_factory
@@ -54,6 +55,17 @@ class RoaringUnion:
 
     def step(self, bitmap):
         self.bitmap |= pyroaring.BitMap.deserialize(bitmap)
+
+    def finalize(self):
+        return self.bitmap.serialize()
+
+
+class RoaringShiftUnion:
+    def __init__(self):
+        self.bitmap = pyroaring.BitMap()
+
+    def step(self, bitmap, shift):
+        self.bitmap |= pyroaring.BitMap.deserialize(bitmap).shift(shift)
 
     def finalize(self):
         return self.bitmap.serialize()

--- a/hyperreal/db_utilities.py
+++ b/hyperreal/db_utilities.py
@@ -37,6 +37,7 @@ def connect_sqlite(db_path, row_factory=None):
 
 
 def save_bitmap(bm):
+    bm.run_optimize()
     return bm.serialize()
 
 
@@ -57,7 +58,7 @@ class RoaringUnion:
         self.bitmap |= pyroaring.BitMap.deserialize(bitmap)
 
     def finalize(self):
-        return self.bitmap.serialize()
+        return save_bitmap(self.bitmap)
 
 
 class RoaringShiftUnion:
@@ -68,4 +69,4 @@ class RoaringShiftUnion:
         self.bitmap |= pyroaring.BitMap.deserialize(bitmap).shift(shift)
 
     def finalize(self):
-        return self.bitmap.serialize()
+        return save_bitmap(self.bitmap)

--- a/hyperreal/db_utilities.py
+++ b/hyperreal/db_utilities.py
@@ -66,7 +66,8 @@ class RoaringShiftUnion:
         self.bitmap = pyroaring.BitMap()
 
     def step(self, bitmap, shift):
-        self.bitmap |= pyroaring.BitMap.deserialize(bitmap).shift(shift)
+        if bitmap is not None:
+            self.bitmap |= pyroaring.BitMap.deserialize(bitmap).shift(shift)
 
     def finalize(self):
         return save_bitmap(self.bitmap)

--- a/hyperreal/index.py
+++ b/hyperreal/index.py
@@ -796,7 +796,9 @@ class Index:
             writer.writeheader()
 
             for cluster_id, sample_docs in sample_docs.items():
-                write_docs = self.docs(sample_docs)
+                write_docs = self.corpus.render_docs_table(
+                    self.convert_query_to_keys(sample_docs)
+                )
 
                 for doc_id, (key, doc) in zip(sample_docs, write_docs):
                     doc["doc_key"] = key
@@ -805,7 +807,7 @@ class Index:
                         if doc_id in cluster_docs:
                             doc[f"cluster_{other_cluster_id}"] = 1
 
-                writer.writerow(doc)
+                    writer.writerow(doc)
 
     def indexed_field_summary(self):
         """
@@ -1223,9 +1225,6 @@ class Index:
             against moving into this cluster. Note that features will
             be removed from this set if they are already in this cluster
             in cluster_feature.
-
-        acceptance_probability is a softening factor, used to prevent
-        cycling between the same states on repeated iteration.
 
         top_k: the number of best scores to keep - the default is to only
             the single best scoring feature.

--- a/hyperreal/index.py
+++ b/hyperreal/index.py
@@ -175,6 +175,12 @@ class Index:
 
         self.corpus = corpus
 
+        self.position_window_size = list(
+            self.db.execute(
+                "select value from settings where key = 'position_window_size'"
+            )
+        )[0][0]
+
         # For tracking the state of nested transactions. This is incremented
         # everytime a savepoint is entered with the @atomic() decorator, and
         # decremented on leaving. Housekeeping functions will run when leaving
@@ -624,6 +630,7 @@ class Index:
 
             tempdir.cleanup()
 
+        self.position_window_size = position_window_size
         self.logger.info("Indexing completed.")
 
     @atomic()
@@ -637,6 +644,22 @@ class Index:
                 )
             )[0][0]
             yield doc_key
+
+    @atomic()
+    def convert_positions_to_query(self, field, positions):
+        """
+        Convert a bitset of positions in a field into a set of doc_ids.
+
+        """
+        pass
+
+    @atomic()
+    def convert_query_to_field_positions(self, field, query):
+        """
+        Convert a set of doc_ids into positions for a specific field.
+
+        """
+        pass
 
     @requires_corpus(corpus.BaseCorpus)
     def docs(self, query):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -107,9 +107,9 @@ def test_indexing(pool, tmp_path, corpus, args, kwargs, check_stats):
         assert (field, value) == features_field_values[feature_id]
 
     i.index(doc_batch_size=100, position_window_size=-1)
-    positions = list(
-        i.db.execute("select sum(position_count) from inverted_position_index")
-    )[0][0]
+    positions = list(i.db.execute("select sum(position_count) from inverted_index"))[0][
+        0
+    ]
     assert positions == target_positions
 
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -131,6 +131,27 @@ def test_indexing(pool, tmp_path, corpus, args, kwargs, check_stats):
             )
         )
 
+        # Test concordances:
+        positions = list(
+            idx.db.execute(
+                """
+                select
+                    positions
+                from inverted_index
+                where field='text' and value = 'hatter'
+                """
+            )
+        )[0][0]
+
+        for doc_key, doc_id, cooccurrence_window in idx.cooccurrence(
+            "text", positions, 1, 5
+        ):
+            assert "hatter" in cooccurrence_window
+            assert len(cooccurrence_window) <= 3 * p
+
+        for doc_key, doc_id, concordance in idx.concordances("text", positions, 1, 5):
+            assert "hatter" in concordance
+
 
 @pytest.mark.parametrize("n_clusters", [4, 16, 64])
 def test_model_creation(pool, example_index_path, n_clusters):


### PR DESCRIPTION
Adds new functionality to record positional information about where values can occur in a sequence - this enables proximity querying in the approximate case, and phrase searching in the exact case.

Currently there is a limitation that a field can have no more than 2**32-1 positions recorded. 